### PR TITLE
4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The text that is displayed when there is no suggestion for a mistake.
 
+### Removed
+- The `i` (ignore) command. You can still temporarily whitelist a word with `w` or ignore it once with `n`.
+
 ## [Unreleased]
 
 ## [3.0.3] - 2017-12-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The text that is displayed when there is no suggestion for a mistake.
+- When a file has no changes, print `No changes` instead of printing the entire file twice.
 
 ### Removed
 - The `i` (ignore) command. You can still temporarily whitelist a word with `w` or ignore it once with `n`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased (4.0)]
 ### Added
 - A progress bar for the automated spellchecking step.
+- Spellchecking for links to anchors within the document (like [this link](#unreleased)).
+- Ignore words in PascalCase, camelCase, and snake_case.
 
 ### Changed
 - The text that is displayed when there is no suggestion for a mistake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When a file has no changes, print `No changes` instead of printing the entire file twice.
 
 ### Removed
-- The `i` (ignore) command. You can still temporarily whitelist a word with `w` or ignore it once with `n`.
+- The `i` (ignore) command. You can still permanently whitelist a word with `w` or ignore it once with `n`.
 
 ## [3.0.3] - 2017-12-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - A progress bar for the automated spellchecking step.
 
+### Changed
+- The text that is displayed when there is no suggestion for a mistake.
+
 ## [Unreleased]
 
 ## [3.0.3] - 2017-12-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased (4.0)]
+## [Unreleased]
 ### Added
 - A progress bar for the automated spellchecking step.
 - Spellchecking for links to anchors within the document (like [this link](#unreleased)).
@@ -18,8 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - The `i` (ignore) command. You can still temporarily whitelist a word with `w` or ignore it once with `n`.
-
-## [Unreleased]
 
 ## [3.0.3] - 2017-12-22
 ### Fixed
@@ -138,8 +136,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The core Github Spellcheck functionality. Hurray!
 
-[Unreleased (4.0)]: https://github.com/tbroadley/github-spellcheck-cli/compare/HEAD...4.0
-[Unreleased]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.2...HEAD
+[Unreleased]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.3...HEAD
 [3.0.3]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.0...v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A progress bar for the automated spellchecking step.
 - Spellchecking for links to anchors within the document (like [this link](#unreleased)).
 - Ignore words in PascalCase, camelCase, and snake_case.
+- Ignore words that contain a period if the last section of the word when split on periods isn't in the dictionary.
+- Ignore words containing a pound symbol (`#`). This will ignore words like `Component#render`.
 
 ### Changed
 - The text that is displayed when there is no suggestion for a mistake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.2] - 2017-12-21
+### Fixed
+- Stop decoding HTML entities because doing so throws off the indices of spelling mistakes.
+
 ## [3.0.1] - 2017-12-21
 ### Added
 - Descriptions of correction commands to README.md.
@@ -115,7 +119,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The core Github Spellcheck functionality. Hurray!
 
-[Unreleased]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.2...HEAD
+[3.0.2]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/tbroadley/github-spellcheck-cli/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/tbroadley/github-spellcheck-cli/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/tbroadley/github-spellcheck-cli/compare/v2.0.0...v2.0.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Command   Meaning           Description
 y         yes               Include this correction in the pull request.
 n         no                Do not include this correction in the pull request.
 d         delete repeated   Delete the word to be corrected and the space in front of it. For example, "the the" will become "the".
-i         ignore            Ignore the word to be corrected for the rest of the session.
 w         whitelist         Permanently whitelist the word to be corrected.
 e         edit              Replace the word to be corrected with a specified word.
 s         skip file         Do not include this correction on any other corrections in this file.

--- a/lib/add-by-user-selection.js
+++ b/lib/add-by-user-selection.js
@@ -36,29 +36,28 @@ async function addToWhitelist(word) {
   await fs.writeFile(WHITELIST_PATH, `${word}\n`, { flag: 'a' });
 }
 
-function skipWord(misspelling, filePath, wordsToSkip, whitelistedWords, filesToSkip) {
-  return _.includes(_.concat(wordsToSkip, whitelistedWords), misspelling) ||
+function skipWord(misspelling, filePath, whitelistedWords, filesToSkip) {
+  return _.includes(whitelistedWords, misspelling) ||
          _.includes(filesToSkip, filePath);
 }
 
-function countRemaining(misspellings, index, wordsToSkip, whitelistedWords, filesToSkip) {
+function countRemaining(misspellings, index, whitelistedWords, filesToSkip) {
   return _.reject(misspellings.slice(index), (misspellingObject) => {
     const { misspelling, path: filePath } = misspellingObject;
-    return skipWord(misspelling, filePath, wordsToSkip, whitelistedWords, filesToSkip);
+    return skipWord(misspelling, filePath, whitelistedWords, filesToSkip);
   }).length;
 }
 
 exports.addByUserSelection = async (misspellings, repo) => {
   const changes = [];
   const diffs = [];
-  const wordsToSkip = [];
   const whitelistedWords = await readWhitelistFile();
   const filesToSkip = [];
   for (let index = 0; index < misspellings.length; index += 1) {
     const misspellingObject = misspellings[index];
     const { misspelling, path: filePath } = misspellingObject;
 
-    if (!skipWord(misspelling, filePath, wordsToSkip, whitelistedWords, filesToSkip)) {
+    if (!skipWord(misspelling, filePath, whitelistedWords, filesToSkip)) {
       // eslint-disable-next-line no-await-in-loop
       const currentFileContents = await readFileToCorrect(filePath, repo);
       const updatedFileContents = applySpellingCorrection(misspellingObject, currentFileContents);
@@ -84,7 +83,6 @@ exports.addByUserSelection = async (misspellings, repo) => {
       const remaining = countRemaining(
         misspellings,
         index,
-        wordsToSkip,
         whitelistedWords,
         filesToSkip
       );
@@ -131,12 +129,6 @@ exports.addByUserSelection = async (misspellings, repo) => {
             });
             await updateFile(fileContents);
           },
-        },
-        {
-          command: 'i',
-          meaning: 'ignore',
-          description: 'Ignore the word to be corrected for the rest of the session.',
-          responseFunction: () => wordsToSkip.push(misspelling),
         },
         {
           command: 'w',

--- a/lib/add-by-user-selection.js
+++ b/lib/add-by-user-selection.js
@@ -19,7 +19,7 @@ async function readFileToCorrect(relativePath, repo) {
 function applySpellingCorrection({ index: { start, end }, suggestions }, document) {
   return [
     document.slice(0, start),
-    suggestions.length > 0 ? suggestions[0] : '[no suggestion found]',
+    suggestions.length > 0 ? suggestions[0] : 'NO SUGGESTIONS',
     document.slice(end),
   ].join('');
 }

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -60,7 +60,7 @@ exports.generateWordDiff = (before, after) => {
   const diff = diffLines(before, after);
 
   if (_.every(diff, ({ removed, added }) => !added && !removed)) {
-    return buildWordDiffFromLines(before, after);
+    return 'No changes';
   }
 
   const removedIndex = _.findIndex(diff, 'removed');

--- a/lib/spellcheck.js
+++ b/lib/spellcheck.js
@@ -664,9 +664,33 @@ function excludeIndex(index, node) {
   );
 }
 
-function filterIndices(indices, document) {
+const camelCaseWord = /^[a-z]+(?:[A-Z][a-z]*)+$/;
+const pascalCaseWord = /^(?:[A-Z][a-z]*){2,}$/;
+const snakeCaseWord = /^[A-Za-z]+(?:_[A-Za-z]+)+$/;
+
+function excludeWord(word) {
+  if (snakeCaseWord.test(word) || word.includes('#')) {
+    return true;
+  }
+
+  const wordParts = _.split(word, '.');
+
+  if (wordParts.length === 1) {
+    return camelCaseWord.test(wordParts[0]) || pascalCaseWord.test(wordParts[0]);
+  }
+  return SpellChecker.isMisspelled(_.last(wordParts));
+}
+
+function filterIndicesAndWords(indices, document) {
   const parsedDocument = parser.parse(document);
-  return _.reject(indices, index => excludeIndex(index, parsedDocument));
+  return _.reject(indices, (index) => {
+    const word = document.substring(index.start, index.end);
+    return excludeIndex(index, parsedDocument) || excludeWord(word);
+  });
+}
+
+function filterWords(indices, document) {
+  return _.reject(indices, ({ start, end }) => excludeWord(document.substring(start, end)));
 }
 
 function isCapitalizationChange({ misspelling, suggestions: [suggestion] }) {
@@ -685,7 +709,9 @@ function onlyPeriodsAdded({ misspelling, suggestions: [suggestion] }) {
 
 exports.getMisspellings = (document, filePath) => SpellChecker.checkSpellingAsync(document)
   .then((indices) => {
-    const filteredIndices = isMarkdown(filePath) ? filterIndices(indices, document) : indices;
+    const filteredIndices = isMarkdown(filePath) ?
+      filterIndicesAndWords(indices, document) :
+      filterWords(indices, document);
     const misspellings = filteredIndices.map(({ start, end }) => document.substring(start, end));
     const allSuggestions = misspellings.map(SpellChecker.getCorrectionsForMisspelling);
     const misspellingObjects = _.zipWith(

--- a/lib/spellcheck.js
+++ b/lib/spellcheck.js
@@ -546,6 +546,24 @@ function inNode(index, node) {
   return _.inRange(index.start, startOffset, endOffset);
 }
 
+function isInLinkUrl(index, node) {
+  const { children, url } = node;
+  const endOffset = getOffsets(node)[1];
+
+  if (_.some(children, child => inNode(index, child))) {
+    return false;
+  }
+
+  if (!url) {
+    return true;
+  }
+
+  const urlEnd = endOffset - 1;
+  const urlStart = urlEnd - url.length;
+  return !_.startsWith(url, '#') ||
+         !_.inRange(index.start, urlStart, urlEnd);
+}
+
 function isInImageUrl(index, node) {
   const { alt } = node;
   const [startOffset, endOffset] = getOffsets(node);
@@ -635,7 +653,7 @@ function excludeIndex(index, node) {
 
   return inNode(index, node) && (
     _.includes(typesToExclude, type) ||
-    ((type === 'link' || type === 'linkReference') && !_.some(children, child => inNode(index, child))) ||
+    ((type === 'link' || type === 'linkReference') && isInLinkUrl(index, node)) ||
     ((type === 'image' || type === 'imageReference') && isInImageUrl(index, node)) ||
     (type === 'html' && isInHtmlTagOrAttribute(index, node)) ||
     (type === 'html' && isInCodeBlock(index, node)) ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-spellcheck-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-spellcheck-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/test/diff-test.js
+++ b/test/diff-test.js
@@ -77,7 +77,7 @@ the lazy dog.
   it('works correctly on identical sentences', () => testGenerateWordDiff({
     before: 'These sentences are identical.',
     after: 'These sentences are identical.',
-    expected: '-These sentences are identical.\n+These sentences are identical.',
+    expected: 'No changes',
   }));
 
   it('works correctly on a sentence with two words combined into one', () => testGenerateWordDiff({

--- a/test/spellcheck-test.js
+++ b/test/spellcheck-test.js
@@ -319,4 +319,11 @@ I'm a reference link, [chekc me please].
     expectedMisspellings: [0, 2, 3],
     fileName: 'README.md',
   }));
+
+  it('spellchecks links to anchors within the same document', () => testSpellcheck({
+    document: '[Contributors](#contributers)',
+    misspellings: ['contributers'],
+    expectedMisspellings: [0],
+    fileName: 'README.md',
+  }));
 });


### PR DESCRIPTION
### Added
- A progress bar for the automated spellchecking step.
- Spellchecking for links to anchors within the document (like [this link](#unreleased)).
- Ignore words in PascalCase, camelCase, and snake_case.
- Ignore words that contain a period if the last section of the word when split on periods isn't in the dictionary.
- Ignore words containing a pound symbol (`#`). This will ignore words like `Component#render`.

### Changed
- The text that is displayed when there is no suggestion for a mistake.
- When a file has no changes, print `No changes` instead of printing the entire file twice.

### Removed
- The `i` (ignore) command. You can still permanently whitelist a word with `w` or ignore it once with `n`.

