### PR TITLE
Rewrite to use Git commands instead of Nodegit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Always fork the given repo, since the GitHub API will return the existing fork if one has already been created.
+- Use Git commands instead of Nodegit.
 
 ## [4.0.0] - 2017-12-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When I'm looking through the documentation of an open-source software project, I
 
 ## Setup
 
-You need to have Node.js and NPM installed.
+You need to have Git, Node.js, and NPM installed.
 
 ```
 $ npm install --global github-spellcheck-cli

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -4,6 +4,7 @@ ESLint
 Github
 Hurray
 NPM
+Nodegit
 Node.js
 PRs
 PascalCase

--- a/lib/add-by-user-selection.js
+++ b/lib/add-by-user-selection.js
@@ -8,7 +8,7 @@ const { formatDiffs, generateWordDiff } = require('./diff');
 const { prompt, respondToUserInput } = require('./user-input');
 
 function getAbsolutePath(relativePath, repo) {
-  return path.join(repo.workdir(), relativePath);
+  return path.join(repo, relativePath);
 }
 
 async function readFileToCorrect(relativePath, repo) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,21 @@
+const { exec: execWithCallback } = require('child_process');
+const path = require('path');
+const promisify = require('es6-promisify');
+
+const exec = promisify(execWithCallback, { multiArgs: true });
+
+function gitPathArgs(repoPath) {
+  return `--work-tree="${repoPath}" --git-dir="${path.join(repoPath, '.git')}"`;
+}
+
+exports.git = (repoPath, command) => exec(`git ${gitPathArgs(repoPath)} ${command}`)
+  .then(([stdout, stderr, error]) => {
+    if (error) throw error;
+    return [stdout, stderr];
+  });
+
+exports.gitNoPathArgs = command => exec(`git ${command}`)
+  .then(([stdout, stderr, error]) => {
+    if (error) throw error;
+    return [stdout, stderr];
+  });

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,11 +1,9 @@
-const { Clone } = require('nodegit');
+const { gitNoPathArgs: git } = require('./git');
 const promiseRetry = require('promise-retry');
 
-exports.cloneWithRetry = (url, clonePath, githubCredentialsOptions) => promiseRetry(
-  (retry, number) => Clone(url, clonePath, {
-    fetchOpts: githubCredentialsOptions,
-  }).catch((error) => {
-    console.log(`Failed to clone ${url}. Trying again... (Attempt ${number} of 3)`);
+exports.cloneWithRetry = (url, clonePath) => promiseRetry(
+  (retry, number) => git(`clone "${url}" "${clonePath}"`).catch((error) => {
+    console.log(`Failed to clone. Trying again... (Attempt ${number} of 3)`);
     retry(error);
   }),
   {


### PR DESCRIPTION
I had some trouble building Nodegit on Ubuntu, so I figure it'll be easier to use plain Git commands instead. This does mean that you have to have Git installed to use the tool.